### PR TITLE
fix: f-string syntax to RegionDoesNotExisting

### DIFF
--- a/WgLestaAPI/Exceptions.py
+++ b/WgLestaAPI/Exceptions.py
@@ -6,7 +6,7 @@ from . import Constants as c
 
 class RegionDoesNotExisting(Exception):
     def __init__(self, value, game_shortname: str) -> None:
-        super().__init__(f"This region \"{value}\" does not existing in API services for the game \"{c.GAMENAMES.LONGNAMES.__dict__[game_shortname.replace(c.CIS_PREFIX, "").upper()]}\". Available regions for this game is: {', '.join(c.SELECTOR[game_shortname]["region"])}")
+        super().__init__(f"This region \"{value}\" does not existing in API services for the game \"{c.GAMENAMES.LONGNAMES.__dict__[game_shortname.replace(c.CIS_PREFIX, '').upper()]}\". Available regions for this game is: {', '.join(c.SELECTOR[game_shortname]['region'])}")
 
 class ShortnameIsNotDefined(Exception):
     def __init__(self, value) -> None:


### PR DESCRIPTION
```log
uv run python -m src.main
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/grin/PycharmProjects/wot-blitz-telegram/src/main.py", line 5, in <module>
    from WgLestaAPI.Application import AsyncApp
  File "/home/grin/PycharmProjects/wot-blitz-telegram/.venv/lib/python3.11/site-packages/WgLestaAPI/Application.py", line 9, in <module>
    from . import Utils
  File "/home/grin/PycharmProjects/wot-blitz-telegram/.venv/lib/python3.11/site-packages/WgLestaAPI/Utils.py", line 7, in <module>
    from . import Exceptions
  File "/home/grin/PycharmProjects/wot-blitz-telegram/.venv/lib/python3.11/site-packages/WgLestaAPI/Exceptions.py", line 9
    super().__init__(f"This region \"{value}\" does not existing in API services for the game \"{c.GAMENAMES.LONGNAMES.__dict__[game_shortname.replace(c.CIS_PREFIX, "").upper()]}\". Available regions for this game is: {', '.join(c.SELECTOR[game_shortname]["region"])}")
                                                                                                                                                                                                                                                                 ^^^^^^
SyntaxError: f-string: unmatched '('
```